### PR TITLE
Some fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,7 @@ license = "MIT"
 [dependencies]
 chrono = { version = "0.4.24", features = ["serde"] }
 reqwest = { version = "0.11.14", features = ["json"] }
-serde = "1.0.157"
-serde_derive = "1.0.157"
+serde = { version = "1.0.157", features = ["derive"] }
 serde_json = "1.0.94"
 url = "2.3.1"
 serde_qs = "0.12.0"

--- a/src/get.rs
+++ b/src/get.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use chrono::{DateTime, FixedOffset, NaiveDate};
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 use crate::deserialize::{
     deserialize_date, deserialize_datetime, deserialize_optional_datetime,

--- a/src/get.rs
+++ b/src/get.rs
@@ -185,7 +185,8 @@ pub type LogbookResponse = Vec<LogbookEntry>;
 pub struct LogbookEntry {
     #[serde(default)]
     pub domain: Option<String>,
-    pub entity_id: String,
+    #[serde(default)]
+    pub entity_id: Option<String>,
 
     #[serde(default)]
     pub message: Option<String>,

--- a/src/post.rs
+++ b/src/post.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
 use serde::Serialize;
-use serde_derive::Serialize;
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -292,8 +292,8 @@ async fn test_good_history_period_async() -> Result<(), Box<dyn std::error::Erro
     assert_eq!(history.len(), 1);
     assert_eq!(history[0].len(), 2);
     assert_eq!(
-        history[0][0].entity_id,
-        Some("sensor.weather_temperature".to_owned())
+        history[0][0].entity_id.as_deref(),
+        Some("sensor.weather_temperature")
     );
     assert_eq!(history[0][0].state, Some(get::StateEnum::Decimal(-3.9)));
 
@@ -359,13 +359,13 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     assert_eq!(logbook.len(), 3);
 
     // First Logbook Entry
-    assert_eq!(logbook[0].domain, Some("alarm_control_panel".to_owned()));
+    assert_eq!(logbook[0].domain.as_deref(), Some("alarm_control_panel"));
     assert_eq!(
         logbook[0].entity_id.as_deref(),
         Some("alarm_control_panel.area_001"),
     );
-    assert_eq!(logbook[0].message, Some("changed to disarmed".to_owned()));
-    assert_eq!(logbook[0].name, Some("Security".to_owned()));
+    assert_eq!(logbook[0].message.as_deref(), Some("changed to disarmed"));
+    assert_eq!(logbook[0].name.as_deref(), Some("Security"));
     assert_eq!(
         logbook[0].when,
         Some(
@@ -379,16 +379,16 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Second Logbook Entry
-    assert_eq!(logbook[1].domain, Some("homekit".to_owned()));
+    assert_eq!(logbook[1].domain.as_deref(), Some("homekit"));
     assert_eq!(
         logbook[1].entity_id.as_deref(),
         Some("alarm_control_panel.area_001")
     );
     assert_eq!(
-        logbook[1].message,
-        Some("send command alarm_arm_night for Security".to_owned())
+        logbook[1].message.as_deref(),
+        Some("send command alarm_arm_night for Security")
     );
-    assert_eq!(logbook[1].name, Some("HomeKit".to_owned()));
+    assert_eq!(logbook[1].name.as_deref(), Some("HomeKit"));
     assert_eq!(
         logbook[1].when,
         Some(
@@ -402,16 +402,16 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     );
 
     // Third Logbook Entry
-    assert_eq!(logbook[2].domain, Some("alarm_control_panel".to_owned()));
+    assert_eq!(logbook[2].domain.as_deref(), Some("alarm_control_panel"));
     assert_eq!(
         logbook[2].entity_id.as_deref(),
         Some("alarm_control_panel.area_001")
     );
     assert_eq!(
-        logbook[2].message,
-        Some("changed to armed_night".to_owned())
+        logbook[2].message.as_deref(),
+        Some("changed to armed_night")
     );
-    assert_eq!(logbook[2].name, Some("Security".to_owned()));
+    assert_eq!(logbook[2].name.as_deref(), Some("Security"));
     assert_eq!(
         logbook[2].when,
         Some(
@@ -718,12 +718,12 @@ async fn test_good_calendars_entity_async() -> Result<(), Box<dyn std::error::Er
         )
     );
     assert_eq!(
-        calendar_entries[1].description,
-        Some("Don't forget to bring balloons".to_owned())
+        calendar_entries[1].description.as_deref(),
+        Some("Don't forget to bring balloons")
     );
     assert_eq!(
-        calendar_entries[1].location,
-        Some("Brian's House".to_owned())
+        calendar_entries[1].location.as_deref(),
+        Some("Brian's House")
     );
 
     mock_server.assert_async().await;

--- a/tests/get_tests.rs
+++ b/tests/get_tests.rs
@@ -361,8 +361,8 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     // First Logbook Entry
     assert_eq!(logbook[0].domain, Some("alarm_control_panel".to_owned()));
     assert_eq!(
-        logbook[0].entity_id,
-        "alarm_control_panel.area_001".to_owned()
+        logbook[0].entity_id.as_deref(),
+        Some("alarm_control_panel.area_001"),
     );
     assert_eq!(logbook[0].message, Some("changed to disarmed".to_owned()));
     assert_eq!(logbook[0].name, Some("Security".to_owned()));
@@ -381,8 +381,8 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     // Second Logbook Entry
     assert_eq!(logbook[1].domain, Some("homekit".to_owned()));
     assert_eq!(
-        logbook[1].entity_id,
-        "alarm_control_panel.area_001".to_owned()
+        logbook[1].entity_id.as_deref(),
+        Some("alarm_control_panel.area_001")
     );
     assert_eq!(
         logbook[1].message,
@@ -404,8 +404,8 @@ async fn test_good_logbook_async() -> Result<(), Box<dyn std::error::Error>> {
     // Third Logbook Entry
     assert_eq!(logbook[2].domain, Some("alarm_control_panel".to_owned()));
     assert_eq!(
-        logbook[2].entity_id,
-        "alarm_control_panel.area_001".to_owned()
+        logbook[2].entity_id.as_deref(),
+        Some("alarm_control_panel.area_001")
     );
     assert_eq!(
         logbook[2].message,

--- a/tests/state_enum.rs
+++ b/tests/state_enum.rs
@@ -2,7 +2,7 @@ use home_assistant_rest::{
     deserialize::{deserialize_optional_state_enum, deserialize_state_enum},
     get::StateEnum,
 };
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
 struct TestStruct {


### PR DESCRIPTION
`serde_derive::Serialize` imports start to conflict when a user of this crate has `serde` with the derive feature enabled. Just use `derive` ourselves, that doesn't do harm.

Second, I had logbook entries without entity_id, so I made that optional.

Cheers, thanks for the crate!

I might come back and throw a websocket API at it some day, but https://github.com/seanmonstar/reqwest/issues/864 seems to be in the way for that :-)


---

FWIW, I just built this with it: https://gitlab.com/rubdos/hasli/

I have some pending code that infers whether someone is in the shower, and I intent to make it a big bigger than that.