### PR TITLE
fix!: make state response user_id an option, as it may be returned as null at times

### DIFF
--- a/src/post.rs
+++ b/src/post.rs
@@ -45,7 +45,7 @@ impl Requestable for StateParams {
 pub struct StateContextStateResponse {
     pub id: String,
     pub parent_id: Option<String>,
-    pub user_id: String,
+    pub user_id: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]

--- a/tests/post_tests.rs
+++ b/tests/post_tests.rs
@@ -58,7 +58,10 @@ async fn test_update_post_states1_async() -> Result<(), Box<dyn std::error::Erro
     );
     assert_eq!(response.context.id, "01GYXD54C8D0YFJ6ASFDGJBJR9");
     assert_eq!(response.context.parent_id, None);
-    assert_eq!(response.context.user_id, Some("ae03ad0cefa6247baf4178ffce416910".to_string()));
+    assert_eq!(
+        response.context.user_id,
+        Some("ae03ad0cefa6247baf4178ffce416910".to_string())
+    );
 
     mock_server.assert_async().await;
 
@@ -163,7 +166,10 @@ async fn test_create_post_states_async() -> Result<(), Box<dyn std::error::Error
     );
     assert_eq!(response.context.id, "01GYXJH920PEZGN2ZB0QRNY763");
     assert_eq!(response.context.parent_id, None);
-    assert_eq!(response.context.user_id, Some("ae03ad0cefa6247baf4178ffce416910".to_string()));
+    assert_eq!(
+        response.context.user_id,
+        Some("ae03ad0cefa6247baf4178ffce416910".to_string())
+    );
 
     mock_server.assert_async().await;
 

--- a/tests/post_tests.rs
+++ b/tests/post_tests.rs
@@ -58,7 +58,7 @@ async fn test_update_post_states1_async() -> Result<(), Box<dyn std::error::Erro
     );
     assert_eq!(response.context.id, "01GYXD54C8D0YFJ6ASFDGJBJR9");
     assert_eq!(response.context.parent_id, None);
-    assert_eq!(response.context.user_id, "ae03ad0cefa6247baf4178ffce416910");
+    assert_eq!(response.context.user_id, Some("ae03ad0cefa6247baf4178ffce416910".to_string()));
 
     mock_server.assert_async().await;
 
@@ -71,7 +71,7 @@ async fn test_update_post_states2_async() -> Result<(), Box<dyn std::error::Erro
 
     let mock_server = create_mock_server(&mut server, "/api/states/climate.thermostat")
         .match_body(r#"{"state":"cool","attributes":{}}"#)
-        .with_body(r#"{"entity_id":"climate.thermostat","state":"cool","attributes":{},"last_changed":"2023-04-26T01:17:56.033828+00:00","last_updated":"2023-04-26T01:17:56.033828+00:00","context":{"id":"01GYXJ6XE1008RBVG58E2NKJ3N","parent_id":null,"user_id":"ae03ad0cefa6247baf4178ffce416910"}}"#)
+        .with_body(r#"{"entity_id":"climate.thermostat","state":"cool","attributes":{},"last_changed":"2023-04-26T01:17:56.033828+00:00","last_updated":"2023-04-26T01:17:56.033828+00:00","context":{"id":"01GYXJ6XE1008RBVG58E2NKJ3N","parent_id":null,"user_id":null}}"#)
         .create_async()
         .await;
 
@@ -109,7 +109,7 @@ async fn test_update_post_states2_async() -> Result<(), Box<dyn std::error::Erro
     );
     assert_eq!(response.context.id, "01GYXJ6XE1008RBVG58E2NKJ3N");
     assert_eq!(response.context.parent_id, None);
-    assert_eq!(response.context.user_id, "ae03ad0cefa6247baf4178ffce416910");
+    assert_eq!(response.context.user_id, None);
 
     mock_server.assert_async().await;
 
@@ -163,7 +163,7 @@ async fn test_create_post_states_async() -> Result<(), Box<dyn std::error::Error
     );
     assert_eq!(response.context.id, "01GYXJH920PEZGN2ZB0QRNY763");
     assert_eq!(response.context.parent_id, None);
-    assert_eq!(response.context.user_id, "ae03ad0cefa6247baf4178ffce416910");
+    assert_eq!(response.context.user_id, Some("ae03ad0cefa6247baf4178ffce416910".to_string()));
 
     mock_server.assert_async().await;
 


### PR DESCRIPTION
Supporting Postman output as per the latest version of Home Assistant:
![image](https://github.com/StefanBossbaly/home-assistant-rest/assets/16911399/5d875d7e-594e-473f-b7de-a9d16b6834b8)

This is a breaking change unfortunately, but the user_id has been null quite a few times when using templates in my integration :(
This might be a HA bug, if you think so I will report it to HA instead.