### PR TITLE
Implement service calls

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -112,6 +112,21 @@ impl Client {
         Ok(request)
     }
 
+    async fn post_body_request<S: Serialize, D: DeserializeOwned>(
+        &self,
+        post_param: post::Request<S>,
+    ) -> Result<D> {
+        let request = self
+            .build_post_request(&post_param.endpoint)
+            .json(&post_param.body)
+            .send()
+            .await?
+            .json::<D>()
+            .await?;
+
+        Ok(request)
+    }
+
     async fn get_text_request(&self, endpoint: &str) -> Result<String> {
         let request = self
             .build_get_request(endpoint)
@@ -544,9 +559,9 @@ impl Client {
         Ok(response)
     }
 
-    /// Calls the `/api/services/<domain>/<service>` endpoint which calls a service. Currently unimplemented.
-    pub async fn post_service(&self) -> Result<()> {
-        unimplemented!()
+    /// Calls the `/api/services/<domain>/<service>` endpoint which calls a service.
+    pub async fn post_service(&self, params: post::CallServiceParams) -> Result<post::CallServiceResponse> {
+        self.post_body_request(params.into_request()).await
     }
 
     /// Calls the `/api/template` endpoint which renders a Home Assistant template.
@@ -554,7 +569,7 @@ impl Client {
         self.post_text_request(params.into_request()).await
     }
 
-    /// Calls the `/api/config/core/check_config` endpoint which triggers a check of the current configuration. Currently unimplemented.
+    /// Calls the `/api/config/core/check_config` endpoint which triggers a check of the current configuration.
     pub async fn post_config_check(&self) -> Result<post::CheckConfigResponse> {
         self.post_request("/api/config/core/check_config").await
     }

--- a/src/post.rs
+++ b/src/post.rs
@@ -1,6 +1,7 @@
-use crate::StateEnum;
+use crate::{get::StateEntry, StateEnum};
 
 use std::collections::HashMap;
+use std::vec::Vec;
 
 use chrono::{DateTime, FixedOffset};
 use serde::{Deserialize, Serialize};
@@ -72,6 +73,27 @@ pub struct EventParams {
     pub event_type: String,
     pub event_data: Option<serde_json::Value>,
 }
+
+pub struct CallServiceParams {
+    pub domain: String,
+    pub service: String,
+    pub service_data: Option<serde_json::Value>,
+}
+
+impl Requestable for CallServiceParams {
+    type S = Option<serde_json::Value>;
+
+    fn into_request(self) -> Request<Self::S> {
+
+        Request {
+            endpoint: format!("/api/services/{}/{}", self.domain, self.service).to_owned(),
+            body: self.service_data,
+        }
+    }
+}
+
+
+pub type CallServiceResponse = Vec<StateEntry>;
 
 impl Requestable for EventParams {
     type S = Option<serde_json::Value>;


### PR DESCRIPTION
This implements the /api/services/<domain>/<service> call. Returning the list of changed states.

There's one thing that can be improved: in the case of an incorrect service call, the result is a failure to decode the response. Ideally it would be a bit clearer what happened.
Maybe I'll get around to improving that, but for now it's better than nothing I suppose :)

Would close #4.